### PR TITLE
Prevent scroll from jumping when textarea is inside a scroll container

### DIFF
--- a/src/autosize.directive.ts
+++ b/src/autosize.directive.ts
@@ -68,8 +68,12 @@ export class Autosize implements AfterViewInit {
       return;
     }
     this.el.style.overflow = 'hidden';
-    this.el.style.height = 'auto';
+    // first adjust or element shrinks
+    if (!this._lastHeight || this.el.scrollHeight < this._lastHeight) {
+      this.el.style.height = 'auto';
+    }
     this.el.style.height = this.el.scrollHeight + 'px';
+    this._lastHeight = this.el.scrollHeight;
   }
 
   updateMinHeight(): void {


### PR DESCRIPTION
Only set 'auto' height style on first adjust or if the element shrinks, to prevent scroll from jumping when the textarea is positioned inside a scroll container